### PR TITLE
Added the delay field in Presence

### DIFF
--- a/src/modules/chats/schemas/presence.ts
+++ b/src/modules/chats/schemas/presence.ts
@@ -7,7 +7,13 @@ export interface PresenceRequest {
 	/**
 	 * Duration of the presence in millisseconds
 	 */
-	duration: number;
+	duration?: number;
+	/**
+	 * Delay of the presence in millisseconds
+	 * this is the correct name of the field
+	 * https://doc.evolution-api.com/v1/api-reference/chat-controller/send-presence#delay
+	 */
+	delay: number;
 	/**
 	 * Presence state
 	 * - `composing`: typing a message


### PR DESCRIPTION
Correcting the duration field, in Presence, to delay, but I left the duration as optional

Because the Evolution API returns: [instance requires property delay]

url: http://{server}/chat/sendPresence/{instance_name}